### PR TITLE
Fix FoV Unload

### DIFF
--- a/source.lua
+++ b/source.lua
@@ -612,20 +612,23 @@ end
 
 local Visuals = { FoV = Visualize("FoV") }
 
-local function ClearVisual(Visual)
-    if Visual and table.find(Visuals, Visual) then
+local function ClearVisual(Visual, Key)
+    local FoundVisual = table.find(Visuals, Visual)
+    if Visual and (FoundVisual or Key == "FoV") then
         if Visual.Destroy then
             Visual:Destroy()
         elseif Visual.Remove then
             Visual:Remove()
         end
-        table.remove(Visuals, table.find(Visuals, Visual))
+        if FoundVisual then
+            table.remove(Visuals, FoundVisual)
+        end
     end
 end
 
 local function ClearVisuals()
-    for _, Visual in next, Visuals do
-        ClearVisual(Visual)
+    for Key, Visual in next, Visuals do
+        ClearVisual(Visual, Key)
     end
 end
 


### PR DESCRIPTION
![image](https://github.com/ttwizz/Open-Aimbot/assets/63375371/761d999f-82aa-458b-a8f3-19f84f2cf705)
There is strange behaviour where the FoV circle is left behind when the script is unloaded.
This pull request aims to resolve the issue, by ignoring if the key "FoV" is not in the Visuals table.